### PR TITLE
Remove wider tables/svgs/code blocks

### DIFF
--- a/blog.css
+++ b/blog.css
@@ -27,8 +27,6 @@ math {
 }
 
 .table-wrapper {
-	margin-left: -7rem;
-	width: 52rem;
 	background-color: #00000010;
 	overflow: auto;
 }
@@ -42,8 +40,6 @@ th, td {
 }
 
 pre {
-	margin-left: -7rem;
-	width: 52rem;
 	font-size: 0.85rem;
 	padding: 0.75rem;
 	overflow: auto;
@@ -96,8 +92,6 @@ pre code {
 	margin-bottom: 1rem;
 }
 .diagram svg {
-	margin-left: -7rem;
-	width: 52rem;
 	height: auto;
 }
 


### PR DESCRIPTION
### Before (code blocks and tables are out of the text flow):

<img width="716" alt="Screenshot 2024-08-24 at 11 02 54" src="https://github.com/user-attachments/assets/3fc098c8-a95e-4b57-a18d-2adff4ab3165">

### After (aligned borders allow for better text flow):
<img width="528" alt="Screenshot 2024-08-24 at 11 00 08" src="https://github.com/user-attachments/assets/6fb3b90c-b260-451b-bfed-5c5757473b19">
